### PR TITLE
Minor bugfix with new request module

### DIFF
--- a/lib/http-digest-client.js
+++ b/lib/http-digest-client.js
@@ -23,6 +23,7 @@ var HTTPDigest = function() {
    //
    HTTPDigest.prototype.request = function(options, callback) {
       var self = this;
+      options.auth.sendImmediately=false; // ensure no basic auth
       request(options, function(err, res, body) {
          self._handleResponse(options, err, res, body, callback);
       }).end();

--- a/lib/http-digest-client.js
+++ b/lib/http-digest-client.js
@@ -44,7 +44,7 @@ var HTTPDigest = function() {
          callback(err, res, body);
       }
       else {
-      	 var path=url.parse('options.url').path; // get path from url
+      	 var path=url.parse(options.url).path; // get path from url
          var challenge = this._parseChallenge(res.headers['www-authenticate']);
          var ha1 = crypto.createHash('md5');
          ha1.update([ this.username, challenge.realm, this.password ].join(':'));

--- a/lib/http-digest-client.js
+++ b/lib/http-digest-client.js
@@ -4,6 +4,7 @@
 // Use together with HTTP Client to perform requests to servers protected
 // by digest authentication.
 //
+var url=require('url'); 
 
 var HTTPDigest = function() {
    var crypto = require('crypto');
@@ -43,11 +44,12 @@ var HTTPDigest = function() {
          callback(err, res, body);
       }
       else {
+      	 var path=url.parse('options.url').path; // get path from url
          var challenge = this._parseChallenge(res.headers['www-authenticate']);
          var ha1 = crypto.createHash('md5');
          ha1.update([ this.username, challenge.realm, this.password ].join(':'));
          var ha2 = crypto.createHash('md5');
-         ha2.update([ options.method, options.path ].join(':'));
+         ha2.update([ options.method, path ].join(':'));
    
          // Generate cnonce
          var cnonce = false;
@@ -77,7 +79,7 @@ var HTTPDigest = function() {
             username : this.username,
             realm : challenge.realm,
             nonce : challenge.nonce,
-            uri : options.path,
+            uri : path,
             qop : challenge.qop,
             response : response.digest('hex'),
             opaque : challenge.opaque


### PR DESCRIPTION
- in order to work you had to set options.path
- if sendImmediately is not set to false, request will try to make a basic auth

TODO: 
- update Readme for request implementation
- update tests (thank you for the tests - helped me a lot)
